### PR TITLE
add fill opacity support.

### DIFF
--- a/psdclass.cpp
+++ b/psdclass.cpp
@@ -248,6 +248,7 @@ PSD::getLayerInfo(int no)
 		SETPROP(dict, lay, width);
 		SETPROP(dict, lay, height);
 		SETPROP(dict, lay, opacity);
+		SETPROP(dict, lay, fill_opacity);
 		bool mask = false;
 		for (std::vector<psd::ChannelInfo>::iterator i = lay.channels.begin();
 				 i != lay.channels.end();
@@ -343,7 +344,7 @@ PSD::_getLayerData(tTJSVariant layer, int no, psd::ImageMode imageMode)
 		TVPThrowExceptionMessage(L"invalid layer type");
 	}
 
-	int left, top, width, height, opacity, type;
+	int left, top, width, height, opacity, fill_opacity, type;
 
 	bool dummyMask = false;
 	if (imageMode == psd::IMAGE_MODE_MASK) {
@@ -352,6 +353,7 @@ PSD::_getLayerData(tTJSVariant layer, int no, psd::ImageMode imageMode)
 		width = mask.width;
 		height = mask.height;
 		opacity = 255;
+                fill_opacity = 255;
 		type = ltPsNormal;
 		if (width == 0 || height == 0) {
 			left = top = 0;
@@ -364,6 +366,7 @@ PSD::_getLayerData(tTJSVariant layer, int no, psd::ImageMode imageMode)
 		width = lay.width;
 		height = lay.height;
 		opacity = lay.opacity;
+                fill_opacity = lay.fill_opacity;
 		type = convBlendMode(lay.blendMode);
 	}
 	if (width <= 0 || height <= 0) {
@@ -375,6 +378,7 @@ PSD::_getLayerData(tTJSVariant layer, int no, psd::ImageMode imageMode)
 	obj.SetValue(L"left", left);
 	obj.SetValue(L"top", top);
 	obj.SetValue(L"opacity", opacity);
+	obj.SetValue(L"fill_opacity", fill_opacity);
 	obj.SetValue(L"width",  width);
 	obj.SetValue(L"height", height);
 	obj.SetValue(L"type",   type);

--- a/psdparse/psddata.h
+++ b/psdparse/psddata.h
@@ -384,8 +384,9 @@ namespace psd {
 		int right;
 		std::vector<ChannelInfo> channels;
 		int blendModeKey;
-    BlendMode blendMode;
+		BlendMode blendMode;
 		int opacity;
+		int fill_opacity;
 		int clipping;
 		int flag;
 		LayerExtraData extraData;

--- a/psdparse/psdlayer.cpp
+++ b/psdparse/psdlayer.cpp
@@ -42,6 +42,12 @@ namespace psd {
     return true;
   }
 
+  bool loadLayerFillOpacity(LayerInfo &layer, AdditionalLayerInfo &additional)
+  {
+    layer.fill_opacity = additional.data->getCh();
+    return true;
+  }
+  
   bool loadLayerMetadata(LayerInfo &layer, AdditionalLayerInfo &additional)
   {
     int count = additional.data->getInt32();

--- a/psdparse/psdlayer.h
+++ b/psdparse/psdlayer.h
@@ -8,5 +8,6 @@ namespace psd {
   bool loadLayerUnicodeName(LayerInfo &layer, AdditionalLayerInfo &additional);
   bool loadLayerId(LayerInfo &layer, AdditionalLayerInfo &additional);
   bool loadLayerMetadata(LayerInfo &layer, AdditionalLayerInfo &additional);
+  bool loadLayerFillOpacity(LayerInfo &layer, AdditionalLayerInfo &additional);
 }
 #endif //  __psdlayer_h__

--- a/psdparse/psdparse.cpp
+++ b/psdparse/psdparse.cpp
@@ -154,7 +154,8 @@ Data::processParsed()
     layer.layerName = layer.extraData.layerName;
     layer.layerType = LAYER_TYPE_NORMAL;
     layer.layerId   = -1;
-
+    layer.fill_opacity = 255;
+    
     // チャネルイメージイテレータをチャネル毎に頭出しコピー
     for (uint32_t ch = 0; ch < layer.channels.size(); ch++) {
       ChannelInfo &channel = layer.channels[ch];
@@ -218,7 +219,10 @@ Data::processParsed()
       case 'shmd': // Metadata setting (Photoshop 6.0)
         success = loadLayerMetadata(layer, additional);
         break;
-
+      case 'iOpa': // fill opacity
+        success = loadLayerFillOpacity(layer, additional);
+        break;
+        
       // --- 未対応 ---
       case 'lrFX': // Effects Layer (Photoshop 5.0)
       case 'tySh': // Type Tool Info (Photoshop 5.0 and 5.5 only)


### PR DESCRIPTION
PhotoShopの「塗りの不透明度」のパラメータを読み込む機能を実装しました。
E-moteエディタで読み込みが正しく出来ていることを確認済みです。
